### PR TITLE
Updated request methods to allow customisation of curb options per-request

### DIFF
--- a/lib/curb-fu.rb
+++ b/lib/curb-fu.rb
@@ -7,20 +7,20 @@ require 'curb-fu/core_ext'
 
 module CurbFu
   class << self
-    def get(*args)
-      CurbFu::Request.get(*args)
+    def get(*args, &block)
+      CurbFu::Request.get(*args, &block)
     end
 
-    def post(*args)
-      CurbFu::Request.post(*args)
+    def post(*args, &block)
+      CurbFu::Request.post(*args, &block)
     end
 
-    def put(*args)
-      CurbFu::Request.put(*args)
+    def put(*args, &block)
+      CurbFu::Request.put(*args, &block)
     end
 
-    def delete(*args)
-      CurbFu::Request.delete(*args)
+    def delete(*args, &block)
+      CurbFu::Request.delete(*args, &block)
     end
   
     attr_accessor :stubs

--- a/lib/curb-fu/request/base.rb
+++ b/lib/curb-fu/request/base.rb
@@ -3,7 +3,7 @@ module CurbFu
     module Base
       include Common
       
-      def build(url_params, query_params = {})
+      def build(url_params, query_params = {}, &block)
         curb = Curl::Easy.new(build_url(url_params, query_params))
 
         headers = global_headers
@@ -23,6 +23,8 @@ module CurbFu
         curb.headers = headers
         curb.timeout = @timeout
 
+        yield curb if block_given?
+
         curb
       end
       
@@ -38,23 +40,23 @@ module CurbFu
         @global_headers ||= {}
       end
       
-      def get(url, params = {})
-        curb = self.build(url, params)
+      def get(url, params = {}, &block)
+        curb = self.build(url, params, &block)
         curb.http_get
         CurbFu::Response::Base.from_curb_response(curb)
       end
 
-      def put(url, params = {})
-        curb = self.build(url, params)
+      def put(url, params = {}, &block)
+        curb = self.build(url, params, &block)
         curb.http_put("")
         CurbFu::Response::Base.from_curb_response(curb)
       end
 
-      def post(url, params = {})
+      def post(url, params = {}, &block)
         fields = create_post_fields(params)
         fields = [fields] if fields.is_a?(String)
 
-        curb = self.build(url)
+        curb = self.build(url, &block)
         curb.http_post(*fields)
         response = CurbFu::Response::Base.from_curb_response(curb)
         if CurbFu.debug?
@@ -66,11 +68,11 @@ module CurbFu
         response
       end
 
-      def post_file(url, params = {}, filez = {})
+      def post_file(url, params = {}, filez = {}, &block)
         fields = create_post_fields(params)
         fields += create_file_fields(filez)
 
-        curb = self.build(url)
+        curb = self.build(url, &block)
         curb.multipart_form_post = true
         
         begin
@@ -82,8 +84,8 @@ module CurbFu
         CurbFu::Response::Base.from_curb_response(curb)
       end
 
-      def delete(url)
-        curb = self.build(url)
+      def delete(url, &block)
+        curb = self.build(url, &block)
         curb.http_delete
         CurbFu::Response::Base.from_curb_response(curb)
       end

--- a/lib/curb-fu/response.rb
+++ b/lib/curb-fu/response.rb
@@ -35,7 +35,10 @@ module CurbFu
         header_lines.shift
         header_lines.inject({}) do |hsh, line|
           whole_enchillada, key, value = /^(.*?):\s*(.*)$/.match(line.chomp).to_a
-          hsh[key] = value unless whole_enchillada.nil?
+          unless whole_enchillada.nil?
+            # note: headers with multiple instances should have multiple values in the headers hash
+            hsh[key] = hsh[key] ? hsh[key].to_a << value : value
+          end
           hsh
         end
       end

--- a/lib/curb-fu/response.rb
+++ b/lib/curb-fu/response.rb
@@ -37,7 +37,7 @@ module CurbFu
           whole_enchillada, key, value = /^(.*?):\s*(.*)$/.match(line.chomp).to_a
           unless whole_enchillada.nil?
             # note: headers with multiple instances should have multiple values in the headers hash
-            hsh[key] = hsh[key] ? hsh[key].to_a << value : value
+            hsh[key] = hsh[key] ? [hsh[key]].flatten << value : value
           end
           hsh
         end
@@ -48,13 +48,13 @@ module CurbFu
       end
 
       def content_length
-        if ( header_value = get_fields('Content-Length').to_a.last )
+        if ( header_value = self['Content-Length'] )
           header_value.to_i
         end
       end
 
       def content_type
-        if ( header_value = get_fields('Content-Type').to_a.last )
+        if ( header_value = self['Content-Type'] )
           header_value.split(';').first
         end
       end

--- a/lib/curb-fu/response.rb
+++ b/lib/curb-fu/response.rb
@@ -60,9 +60,16 @@ module CurbFu
       end
 
       def get_fields(key)
-        @headers.find{|k,v| k.downcase == key.downcase}.to_a.last
+        if ( match = @headers.find{|k,v| k.downcase == key.downcase} )
+          [match.last].flatten
+        else
+          []
+        end
       end
-      alias_method :[], :get_fields
+
+      def [](key)
+        get_fields(key).last
+      end
 
       def set_response_type(status)
         case status

--- a/lib/curb-fu/response.rb
+++ b/lib/curb-fu/response.rb
@@ -46,7 +46,24 @@ module CurbFu
       def to_hash
         { :status => status, :body => body, :headers => headers }
       end
-      
+
+      def content_length
+        if ( header_value = get_fields('Content-Length').to_a.last )
+          header_value.to_i
+        end
+      end
+
+      def content_type
+        if ( header_value = get_fields('Content-Type').to_a.last )
+          header_value.split(';').first
+        end
+      end
+
+      def get_fields(key)
+        @headers.find{|k,v| k.downcase == key.downcase}.to_a.last
+      end
+      alias_method :[], :get_fields
+
       def set_response_type(status)
         case status
         when 100..199 then

--- a/spec/lib/curb-fu/response_spec.rb
+++ b/spec/lib/curb-fu/response_spec.rb
@@ -106,6 +106,13 @@ describe CurbFu::Response::Base do
         @cf.headers['Content-Length'].should == '18'
         @cf.headers.keys.length.should == 5
       end
+
+      it "should use an array to store values for headers fields with multiple instances" do
+        headers = "HTTP/1.1 200 OK\r\nSet-Cookie: first cookie value\r\nSet-Cookie: second cookie value\r\n\r\n"
+        mock_curb = mock(Object, :response_code => 200, :body_str => 'OK', :header_str => headers, :timeout= => nil)
+        @cf = CurbFu::Response::Base.from_curb_response(mock_curb)
+        @cf.headers['Set-Cookie'].should == ["first cookie value", "second cookie value"]
+      end
     end
   end
 end

--- a/spec/lib/curb-fu/response_spec.rb
+++ b/spec/lib/curb-fu/response_spec.rb
@@ -165,7 +165,7 @@ describe CurbFu::Response::Base do
 
   describe "content_length" do
 
-    it "should return the last content-length header field value" do
+    it "should return the last content-length header field value, as an integer" do
       headers = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\nContent-Length: 18\r\n\r\n"
       mock_curb = mock(Object, :response_code => 200, :body_str => 'OK', :header_str => headers, :timeout= => nil)
       @cf = CurbFu::Response::Base.from_curb_response(mock_curb)

--- a/spec/lib/curb-fu/response_spec.rb
+++ b/spec/lib/curb-fu/response_spec.rb
@@ -126,14 +126,45 @@ describe CurbFu::Response::Base do
 
     it "should return an array containing all matching field values" do
       @cf.get_fields("Set-Cookie").should == ["first cookie value", "second cookie value"]
+      @cf.get_fields("Content-Length").should == ["18"]
     end
 
     it "should do a case-insensitive match of the key to header fields" do
-      @cf.get_fields("Set-cookie").should == ["first cookie value", "second cookie value"]
+      @cf.get_fields("content-length").should == ["18"]
+    end
+
+    it "should return empty array when key matches no header field" do
+      @cf.get_fields("non-existent").should == []
+    end
+
+  end
+
+  describe "[]" do
+
+    before(:each) do
+      headers = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=ISO-8859-1\r\nContent-Length: 18\r\nSet-Cookie: first cookie value\r\nServer: gws\r\nTransfer-Encoding: chunked\r\nSet-Cookie: second cookie value\r\n\r\n"
+      mock_curb = mock(Object, :response_code => 200, :body_str => 'OK', :header_str => headers, :timeout= => nil)
+      @cf = CurbFu::Response::Base.from_curb_response(mock_curb)
+    end
+
+    it "should return the last matching field value" do
+      @cf["Set-Cookie"].should == "second cookie value"
+    end
+
+    it "should return the entire header value" do
+      @cf["Content-Type"].should == "text/html; charset=ISO-8859-1"
+    end
+
+    it "should return the header value as a string" do
+      @cf["Content-Length"].should == "18"
+    end
+
+    it "should do a case-insensitive match of the key to header fields" do
+      @cf["content-length"].should == "18"
     end
 
     it "should return nil when key matches no header field" do
-      @cf.get_fields("non-existent").should == nil
+      @cf["non-existent"].should == nil
     end
 
   end
@@ -145,7 +176,7 @@ describe CurbFu::Response::Base do
       mock_curb = mock(Object, :response_code => 200, :body_str => 'OK', :header_str => headers, :timeout= => nil)
       @cf = CurbFu::Response::Base.from_curb_response(mock_curb)
       @cf.content_type.should == "text/html"
-    end    
+    end
 
     it "should return the content-type from the last header field value" do
       headers = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=ISO-8859-1\r\nContent-Length: 18\r\nContent-Type: application/xhtml+xml; charset=UTF-8\r\n\r\n"


### PR DESCRIPTION
Hi,

Thanks for curb-fu, which is just what I was looking for -  a clean and simple interface to libcurl.

I ran into one problem early on though, I need to specify request timeouts per-request, and from what I can tell, the timeout option is a class attribute that applies to all instances of CurbFu::Request. While this would work in a single-threaded environment, it still felt wrong, so I updated the various class methods of CurbFu::Request to allow the timeout, and other options, be customised per-request.

In my updated version of the code, if a block is supplied to any of the class methods that send http requests, the instance of Curl::Easy will be yielded to the block just before the request is sent. This means I can now do this:

resp = CurbFu.get('http://localhost') {|curb| curb.timeout = 5}

rather than:

CurbFu::Request.timeout = 5
resp = CurbFu.get('http://localhost')

While it might seem dangerous, it seems sensible to me to hand both power and responsibility to the developer, so this works for me. May not be your cup of tea, but if it is, you may wish to pull it in.

Mark
