### PR TITLE
Renamed to_param method

### DIFF
--- a/lib/curb-fu/core_ext.rb
+++ b/lib/curb-fu/core_ext.rb
@@ -1,19 +1,19 @@
 require 'cgi'
 
 ##
-# ActiveSupport look alike for to_param. Very useful.
+# ActiveSupport look alike for to_param_pair. Very useful.
 module CurbFu
   module HashExtensions
     def self.included(base)
-      base.send(:include, InstanceMethods) unless base.instance_methods.include?("to_param")
+      base.send(:include, InstanceMethods)
       #base.extend(ClassMethods)
     end
     
     module InstanceMethods
-      def to_param(prefix)
+      def to_param_pair(prefix)
         collect do |k, v|
           key_prefix = prefix ? "#{prefix}[#{k}]" : k
-          v.to_param(key_prefix)
+          v.to_param_pair(key_prefix)
         end.join("&")
       end
     end
@@ -21,12 +21,12 @@ module CurbFu
   
   module ObjectExtensions
     def self.included(base)
-      base.send(:include, InstanceMethods) unless base.instance_methods.include?("to_param")
+      base.send(:include, InstanceMethods)
       #base.extend(ClassMethods)
     end
     
     module InstanceMethods
-      def to_param(prefix = self.class)
+      def to_param_pair(prefix = self.class)
         value = CGI::escape(to_s)
         "#{prefix}=#{value}"
       end
@@ -35,14 +35,14 @@ module CurbFu
   
   module ArrayExtensions
     def self.included(base)
-      base.send(:include, InstanceMethods) unless base.instance_methods.include?("to_param")
+      base.send(:include, InstanceMethods)
       #base.extend(ClassMethods)
     end
     
     module InstanceMethods
-      def to_param(prefix)
+      def to_param_pair(prefix)
         prefix = "#{prefix}[]"
-        collect { |item| "#{item.to_param(prefix)}" }.join('&')
+        collect { |item| "#{item.to_param_pair(prefix)}" }.join('&')
       end
     end
   end

--- a/lib/curb-fu/request/parameter.rb
+++ b/lib/curb-fu/request/parameter.rb
@@ -9,7 +9,7 @@ module CurbFu
       end
       
       def self.build_uri_params(param_hash)
-        param_hash.to_param
+        param_hash.to_param_pair
       end
       
       def self.build_post_fields(param_hash)
@@ -17,11 +17,11 @@ module CurbFu
       end
       
       def to_uri_param
-        value.to_param(name)
+        value.to_param_pair(name)
       end
       
       def to_curl_post_field
-        field_string = value.to_param(name)
+        field_string = value.to_param_pair(name)
         fields = field_string.split('&').collect do |field_value_pair|
           field_name, field_value = field_value_pair.split('=')
           Curl::PostField.content(field_name, CGI::unescape(field_value))

--- a/spec/lib/curb-fu/core_ext_spec.rb
+++ b/spec/lib/curb-fu/core_ext_spec.rb
@@ -7,62 +7,40 @@ describe "module inclusion" do
       include CurbFu::ObjectExtensions
     end
     
-    Tester.new.should respond_to(:to_param)
-  end
-  it "should not overwrite a pre-existing method named :to_param" do
-    class TesterWithToParam
-      def to_param
-        "hooray, to_param!"
-      end
-    end
-    
-    TesterWithToParam.send(:include, CurbFu::ObjectExtensions)
-    TesterWithToParam.new.to_param.should == "hooray, to_param!"
-  end
-  it "should not overwrite the pre-existing method even if it comes from a module" do
-    module ActsLikeRails
-      def to_param
-        "foo"
-      end
-    end
-    class TesterWithModule
-      include ActsLikeRails
-    end
-    TesterWithModule.send(:include, CurbFu::ObjectExtensions)
-    TesterWithModule.new.to_param.should == "foo"
+    Tester.new.should respond_to(:to_param_pair)
   end
 end
 
 describe String do
-  it "should respond_to #to_param" do
-    "".should respond_to(:to_param)
+  it "should respond_to #to_param_pair" do
+    "".should respond_to(:to_param_pair)
   end
-  describe "to_param" do
+  describe "to_param_pair" do
     it "should return itself as the value for the passed-in name" do
-      "foo".to_param("quux").should == "quux=foo"
+      "foo".to_param_pair("quux").should == "quux=foo"
     end
     it "should be CGI escaped" do
-      "Whee, some 'unsafe' uri things".to_param("safe").should == "safe=Whee%2C+some+%27unsafe%27+uri+things"
+      "Whee, some 'unsafe' uri things".to_param_pair("safe").should == "safe=Whee%2C+some+%27unsafe%27+uri+things"
     end
   end
 end
 
 describe Hash do
-  it "should respond to #to_param" do
-    {}.should respond_to(:to_param)
+  it "should respond to #to_param_pair" do
+    {}.should respond_to(:to_param_pair)
   end
-  describe "to_param" do
+  describe "to_param_pair" do
     it "should collect its keys and values into parameter pairs, prepending the provided prefix" do
       {
         "kraplach" => "messy",
         "zebot" => 2003
-      }.to_param("things").should == "things[kraplach]=messy&things[zebot]=2003"
+      }.to_param_pair("things").should == "things[kraplach]=messy&things[zebot]=2003"
     end
     it "should handle having an array as one of its parameters" do
       result = {
         "vielleicht" => "perhaps",
         "ratings" => [5, 3, 5, 2, 4]
-      }.to_param("things")
+      }.to_param_pair("things")
       result.split('&').size.should == 6
       result.should =~ /things\[vielleicht\]=perhaps/
       result.should =~ /things\[ratings\]\[\]=5/
@@ -75,26 +53,26 @@ describe Hash do
 end
 
 describe Array do
-  it "should respond_to #to_param" do
-    [].should respond_to(:to_param)
+  it "should respond_to #to_param_pair" do
+    [].should respond_to(:to_param_pair)
   end
-  describe "to_param" do
+  describe "to_param_pair" do
     it "should join each element, prepending a provided key prefix" do
-      [1, 23, 5].to_param("magic_numbers").should == ["magic_numbers[]=1", "magic_numbers[]=23", "magic_numbers[]=5"].join("&")
+      [1, 23, 5].to_param_pair("magic_numbers").should == ["magic_numbers[]=1", "magic_numbers[]=23", "magic_numbers[]=5"].join("&")
     end
-    it "should call to_param on each element, too" do
-      [1, 23, {"barkley" => 5}].to_param("magic_numbers").should == "magic_numbers[]=1&magic_numbers[]=23&magic_numbers[][barkley]=5"
+    it "should call to_param_pair on each element, too" do
+      [1, 23, {"barkley" => 5}].to_param_pair("magic_numbers").should == "magic_numbers[]=1&magic_numbers[]=23&magic_numbers[][barkley]=5"
     end
   end
 end
 
 describe Integer do
-  it "should respond_to #to_param" do
-    1.should respond_to(:to_param)
+  it "should respond_to #to_param_pair" do
+    1.should respond_to(:to_param_pair)
   end
-  describe "to_param" do
+  describe "to_param_pair" do
     it "should return a stringified version of itself, using the provided key" do
-      5.to_param("fixnum").should == "fixnum=5"
+      5.to_param_pair("fixnum").should == "fixnum=5"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require "rubygems"
-require 'spec'
 require 'htmlentities'
 
 dir = File.dirname(__FILE__)


### PR DESCRIPTION
Like the subject states, I renamed the `to_param` method to `to_param_pair`.  It was causing problems when using curb-fu within a Rails project.  The `unless` check you added caused it not to clobber the Rails method, but the side-effect was that it didn't define the `to_param` method at all.  So when `Parameter#to_param` was called, it was calling the Rails method defined in `Object`, which doesn't accept a parameter.

I created a branch named _rails_ for this fix in case you didn't want to merge the change into master.  I would recommend merging to master and blowing away the rails branch, however, so you don't have to worry about porting new development to the rails branch in order for us Rails guys to keep enjoying CurbFu!

BTW, my commit message isn't exactly accurate.  The `to_param` method doesn't clobber the Rails method.  Feel free to edit it when you merge it in.
