### PR TITLE
Allow passing url as string AND passing headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ however you feel best.
 
     $ gem install curb-fu --source http://gems.github.com
 
-Or, if you ahve the source:
+Or, if you have the source:
 
     $ cd <source-dir>
     $ rake gem
@@ -51,6 +51,11 @@ through their respective methods on CurbFu and CurbFu::Request.
 
     response = CurbFu.post('http://example.com/some/resource', { :color => 'red', :shape => 'sphere' })
     puts response.body unless response.success?
+
+If you need to pass custom headers, you can still pass a string URL with :url :
+
+    response = CurbFu.post(:url => 'http://example.com/some/resource', :headers => {'Content-Type' => 'application/xml'})
+
 
 ### Hash Examples
 

--- a/lib/curb-fu/request/base.rb
+++ b/lib/curb-fu/request/base.rb
@@ -50,8 +50,11 @@ module CurbFu
       end
 
       def put(url, params = {}, cookies = nil, &block)
-        curb = self.build(url, params, &block)
-        curb.http_put("")
+        fields = create_post_fields(params)
+        fields = [fields] if fields.is_a?(String)
+
+        curb = self.build(url, {}, cookies, &block)
+        curb.http_put(*fields)
         CurbFu::Response::Base.from_curb_response(curb)
       end
 

--- a/lib/curb-fu/request/base.rb
+++ b/lib/curb-fu/request/base.rb
@@ -88,7 +88,7 @@ module CurbFu
       end
 
       def delete(url, cookies = nil, &block)
-        curb = self.build(url, cookies, &block)
+        curb = self.build(url, {}, cookies, &block)
         curb.http_delete
         CurbFu::Response::Base.from_curb_response(curb)
       end

--- a/lib/curb-fu/request/common.rb
+++ b/lib/curb-fu/request/common.rb
@@ -12,6 +12,8 @@ module CurbFu
       def build_url(url_params, query_params = {})
         if url_params.is_a? String
           built_url = url_params
+        elsif url_params[:url]
+          built_url = url_params[:url]
         else
           protocol = url_params[:protocol] || "http"
           built_url = "#{protocol}://#{url_params[:host]}"

--- a/spec/lib/curb-fu/request/base_spec.rb
+++ b/spec/lib/curb-fu/request/base_spec.rb
@@ -190,6 +190,22 @@ describe CurbFu::Request::Base do
     end
   end
   
+  describe "delete" do
+    before(:each) do
+      @resource_link = 'http://example.com/resource/1'
+      @mock_curb = mock(Curl::Easy, :headers= => nil, :headers => {}, :header_str => "", :response_code => 200, :body_str => 'yeeeah', :timeout= => nil)
+      Curl::Easy.stub!(:new).and_return(@mock_curb)
+    end
+
+    it "should send each parameter to Curb#http_delete" do
+      Curl::Easy.should_receive(:new).with(@resource_link).and_return(@mock_curb)
+      @mock_curb.should_receive(:http_delete)
+
+      response = TestHarness.delete(@resource_link)
+    end
+  end
+  
+  
   describe "create_post_fields" do
     it "should return the params if params is a string" do
       TestHarness.create_post_fields("my awesome data that I'm sending to you").

--- a/spec/lib/curb-fu/request/base_spec.rb
+++ b/spec/lib/curb-fu/request/base_spec.rb
@@ -30,6 +30,9 @@ describe CurbFu::Request::Base do
     it "should return a string if a string parameter is given" do
       TestHarness.build_url("http://www.cliffsofinsanity.com").should == "http://www.cliffsofinsanity.com"
     end
+    it "should return a string if a :url paramter is given" do
+      TestHarness.build_url(:url => "http://www.cliffsofinsanity.com", :headers => { 'Content-Type' => 'cash/dollars' }).should == "http://www.cliffsofinsanity.com"
+    end
     it "should return a built url with just a hostname if only the hostname is given" do
       TestHarness.build_url(:host => "poisonedwine.com").should == "http://poisonedwine.com"
     end

--- a/spec/lib/curb-fu/request/base_spec.rb
+++ b/spec/lib/curb-fu/request/base_spec.rb
@@ -181,9 +181,12 @@ describe CurbFu::Request::Base do
     end
 
     it "should send each parameter to Curb#http_put" do
-      Curl::Easy.should_receive(:new).with('http://google.com:80/search?q=derek&r=matt').and_return(@mock_curb)
-      @mock_curb.should_receive(:http_put)
+      @mock_q = Curl::PostField.content('q','derek')
+      @mock_r = Curl::PostField.content('r','matt')
+      TestHarness.stub!(:create_post_fields).and_return([@mock_q,@mock_r])
 
+      @mock_curb.should_receive(:http_put).with(@mock_q,@mock_r)
+      
       response = TestHarness.put(
         {:host => "google.com", :port => 80, :path => "/search"},
         { 'q' => 'derek', 'r' => 'matt' })


### PR DESCRIPTION
Hey there,

Currently, if you need to pass the :headers hash, you must pass the URL
as a hash; this means if you have a URL that's a string, you have to
break it apart (and pass :host, :protocol, etc), and then CurbFu puts it back together again.

This change allows passing :url 

(The API here isn't perfect -- it's not clear to me why headers are passed
in what seems to be the URL hash. But, this works, and is compatible
with the current API.)

thanks
david
