### PR TITLE
Fixnum deprecated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: .
   specs:
     curb-fu (0.6.2)
-      curb (>= 0.5.4.0)
+      curb (>= 0.9.3.0)
       rack-test (>= 0.2.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    curb (0.8.2)
+    curb (0.9.3)
     diff-lcs (1.1.3)
     htmlentities (4.3.1)
-    rack (1.4.1)
-    rack-test (0.6.2)
+    rack (1.6.8)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rake (0.9.2.2)
     rspec (2.11.0)
@@ -32,3 +32,6 @@ DEPENDENCIES
   htmlentities
   rake
   rspec
+
+BUNDLED WITH
+   1.14.6

--- a/curb-fu.gemspec
+++ b/curb-fu.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables     = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths   = ["lib"]
 
-  s.add_dependency('curb',   '>= 0.5.4.0')
+  s.add_dependency('curb',   '>= 0.9.3.0')
   s.add_dependency('rack-test',   '>= 0.2.0')
 
   s.add_development_dependency('rake')

--- a/curb-fu.gemspec
+++ b/curb-fu.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.executables     = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths   = ["lib"]
 
+  s.required_ruby_version = '>= 2.4'
+
   s.add_dependency('curb',   '>= 0.9.3.0')
   s.add_dependency('rack-test',   '>= 0.2.0')
 

--- a/lib/curb-fu/core_ext.rb
+++ b/lib/curb-fu/core_ext.rb
@@ -8,7 +8,7 @@ module CurbFu
       base.send(:include, InstanceMethods)
       #base.extend(ClassMethods)
     end
-    
+
     module InstanceMethods
       def to_param_pair(prefix)
         collect do |k, v|
@@ -18,13 +18,13 @@ module CurbFu
       end
     end
   end
-  
+
   module ObjectExtensions
     def self.included(base)
       base.send(:include, InstanceMethods)
       #base.extend(ClassMethods)
     end
-    
+
     module InstanceMethods
       def to_param_pair(prefix = self.class)
         value = CGI::escape(to_s)
@@ -32,13 +32,13 @@ module CurbFu
       end
     end
   end
-  
+
   module ArrayExtensions
     def self.included(base)
       base.send(:include, InstanceMethods)
       #base.extend(ClassMethods)
     end
-    
+
     module InstanceMethods
       def to_param_pair(prefix)
         prefix = "#{prefix}[]"
@@ -57,6 +57,6 @@ end
 class String
   include CurbFu::ObjectExtensions
 end
-class Fixnum
+class Integer
   include CurbFu::ObjectExtensions
 end

--- a/spec/lib/curb-fu/core_ext_spec.rb
+++ b/spec/lib/curb-fu/core_ext_spec.rb
@@ -6,7 +6,7 @@ describe "module inclusion" do
     class Tester
       include CurbFu::ObjectExtensions
     end
-    
+
     Tester.new.should respond_to(:to_param_pair)
   end
 end
@@ -72,7 +72,7 @@ describe Integer do
   end
   describe "to_param_pair" do
     it "should return a stringified version of itself, using the provided key" do
-      5.to_param_pair("fixnum").should == "fixnum=5"
+      5.to_param_pair("integer").should == "integer=5"
     end
   end
 end


### PR DESCRIPTION
Minor update to fix the deprecation warning on Fixnum in Ruby 2.4. 